### PR TITLE
Removing the stringer (latest by go get) that break go lang 1.10.8 wi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ package:
 
 deps:
 	go get github.com/mitchellh/gox
-	go get golang.org/x/tools/cmd/stringer
+#	go get golang.org/x/tools/cmd/stringer  This is breaking go1.10.8, and it's a gigantic nightware to rev to 1.12 which break even more stuff.  It doesn't seem to be harmful to leave this out.
 	go get github.com/kardianos/govendor
 	govendor sync
 


### PR DESCRIPTION
Just remove the stringer external to make the golang 1.10.8 continue to work with the deps checking.
The newer golang compiler (1.12) no longer works with the older packer code, and we are on a borrowed time.